### PR TITLE
added missing dtStart getter

### DIFF
--- a/src/Eluceo/iCal/Component/Event.php
+++ b/src/Eluceo/iCal/Component/Event.php
@@ -377,6 +377,11 @@ class Event extends Component
         return $this;
     }
 
+    public function getDtStart()
+    {
+        return $this->dtStart;
+    }
+
     /**
      * @param $dtStamp
      *


### PR DESCRIPTION
Missing function `getDtStart` function from `Eluceo\iCal\Component\Event`